### PR TITLE
Update runtime dedup in base.config

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -37,7 +37,7 @@ process {
     cpus = { check_max( 18 * task.attempt, 'cpus' ) }
   }
   withName:dedup {
-    time = { check_max( 14.h * task.attempt, 'time' ) }
+    time = { check_max( 30.h * task.attempt, 'time' ) }
   }
   withName:assemble{
     time = { check_max( 8.h * task.attempt, 'time' ) } 


### PR DESCRIPTION
Added more time to dedup (30h)

5 more samples run through, but there are still 3 not running through due to a runtime issue.