### PR TITLE
Report channel fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - 2021-07-13 "Lumos"
+## [2.0.0] - 2021-07-15 "Lumos"
 
 ### :warning: Major enhancements
 
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [#87](https://github.com/nf-core/bcellmagic/pull/87): Order sequence logs by sample ID.
 * [#104](https://github.com/nf-core/bcellmagic/pull/104): Fix bug in pairseq barcode copy before consensus.
 * [#114](https://github.com/nf-core/bcellmagic/pull/114): Analysis not restricted to Ig heavy chains.
+* [#123](https://github.com/nf-core/bcellmagic/pull/123): Fix report Rmarkdown reading for running on AWS.
 
 ### `Dependencies`
 

--- a/bcellmagic.nf
+++ b/bcellmagic.nf
@@ -79,7 +79,7 @@ ch_multiqc_config        = Channel.fromPath("$projectDir/assets/multiqc_config.y
 ch_multiqc_custom_config = params.multiqc_config ? Channel.fromPath(params.multiqc_config) : Channel.empty()
 
 // Rmarkdown report file
-ch_rmarkdown_report      = channel.fromPath( ["$projectDir/assets/repertoire_comparison.Rmd",
+ch_rmarkdown_report      = Channel.fromPath( ["$projectDir/assets/repertoire_comparison.Rmd",
                                     "$projectDir/assets/references.bibtex",
                                     "$projectDir/assets/nf-core_style.css",
                                     "$projectDir/assets/nf-core-bcellmagic_logo.png"], 

--- a/bcellmagic.nf
+++ b/bcellmagic.nf
@@ -75,7 +75,7 @@ if( params.imgtdb_base ){
 /* --          CONFIG FILES                    -- */
 ////////////////////////////////////////////////////
 
-ch_multiqc_config        = channel.fromPath("$projectDir/assets/multiqc_config.yaml", checkIfExists: true)
+ch_multiqc_config        = Channel.fromPath("$projectDir/assets/multiqc_config.yaml", checkIfExists: true)
 ch_multiqc_custom_config = params.multiqc_config ? Channel.fromPath(params.multiqc_config) : Channel.empty()
 
 // Rmarkdown report file

--- a/modules/local/alakazam/alakazam_shazam_repertoires.nf
+++ b/modules/local/alakazam/alakazam_shazam_repertoires.nf
@@ -21,6 +21,7 @@ process ALAKAZAM_SHAZAM_REPERTOIRES {
     input:
     path(tab) // sequence tsv table in AIRR format
     path("Table_sequences.tsv")
+    path(repertoire_report)
 
     output:
     path("*.version.txt"), emit: version
@@ -30,7 +31,7 @@ process ALAKAZAM_SHAZAM_REPERTOIRES {
     script:
     def software = getSoftwareName(task.process)
     """
-    execute_report.R "$projectDir/assets/repertoire_comparison.Rmd"
+    execute_report.R repertoire_comparison.Rmd
     Rscript -e "library(alakazam); write(x=as.character(packageVersion('alakazam')), file='${software}.version.txt')"
     Rscript -e "library(shazam); write(x=as.character(packageVersion('shazam')), file='shazam.version.txt')"
     echo \$(R --version 2>&1) | awk -F' '  '{print \$3}' > R.version.txt


### PR DESCRIPTION
- Adds the report Rmarkdown to a channel instead of reading directly from assets, to fix errors running on AWS

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/bcellmagic/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/bcellmagic _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
