### PR TITLE
Back to NXF 21.04.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['21.04.1', '']
+        nxf_ver: ["21.04.0", ""]
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2
@@ -49,8 +49,8 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['21.04.1', '']
-        profile: ['test_tcr']
+        nxf_ver: ["21.04.0", ""]
+        profile: ["test_tcr"]
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [#87](https://github.com/nf-core/bcellmagic/pull/87): Added tests for TCR data
 * [#102](https://github.com/nf-core/bcellmagic/pull/102): Added param `--protocol`.
 * [#102](https://github.com/nf-core/bcellmagic/pull/102): Added support for C-primer in any R1 or R2 with param `--cprimer_position`.
-* [#102](https://github.com/nf-core/bcellmagic/pull/102): Bump versions to 2.0 and NXF 21.04.1.
+* [#102](https://github.com/nf-core/bcellmagic/pull/102): Bump versions to 2.0.
 * [#103](https://github.com/nf-core/bcellmagic/pull/103): Added full size tests (pcr_umi).
 * [#114](https://github.com/nf-core/bcellmagic/pull/114): Added parameter `--skip_lineages`.
 * [#112](https://github.com/nf-core/bcellmagic/pull/112): Template update to nf-core tools v1.14.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub Actions Linting Status](https://github.com/nf-core/bcellmagic/workflows/nf-core%20linting/badge.svg)](https://github.com/nf-core/bcellmagic/actions?query=workflow%3A%22nf-core+linting%22)
 [![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/bcellmagic/results)
 [![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.2642009-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.2642009)
-[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A521.04.1-23aa62.svg?labelColor=000000)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A521.04.0-23aa62.svg?labelColor=000000)](https://www.nextflow.io/)
 [![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)
 [![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)
 [![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)
@@ -45,7 +45,7 @@ By default, the pipeline currently performs the following steps:
 
 ## Quick Start
 
-1. Install [`Nextflow`](https://nf-co.re/usage/installation) (`>=21.04.1`)
+1. Install [`Nextflow`](https://nf-co.re/usage/installation) (`>=21.04.0`)
 
 2. Install any of [`Docker`](https://docs.docker.com/engine/installation/), [`Singularity`](https://www.sylabs.io/guides/3.0/user-guide/), [`Podman`](https://podman.io/), [`Shifter`](https://nersc.gitlab.io/development/shifter/how-to-use/) or [`Charliecloud`](https://hpc.github.io/charliecloud/) for full pipeline reproducibility _(please only use [`Conda`](https://conda.io/miniconda.html) as a last resort; see [docs](https://nf-co.re/usage/configuration#basic-configuration-profiles))_
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -190,7 +190,7 @@ manifest {
     homePage        = 'https://github.com/nf-core/bcellmagic'
     description     = 'B and T cell repertoire analysis pipeline with the Immcantation framework.'
     mainScript      = 'main.nf'
-    nextflowVersion = '!>=21.04.1'
+    nextflowVersion = '!>=21.04.0'
     version         = '2.0.0'
 }
 


### PR DESCRIPTION
Nextflow tower does not support `21.04.1` yet, so the AWS tests are failing for that NXF version.

This PR sets back the `21.04.0` minimum version.